### PR TITLE
Updating TextCutter to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,27 @@
-TextCutter is a plugin for Figma to cut multiline text into separate layers.
+# TextCutter
 
-Watch the demo video: http://dropzone.johanronsse.be/textcutter-demo.mp4
+TextCutter is a lightweight plugin for Figma to split or join text layers. There is no UI and it's focused on speed of interaction.
 
-I built this plugin to experiment with the Figma plugin API. Finally found some time to give it an update one year later.
+Plugin have two commands:
 
-It's stable now, but it could still use some improvements like better positioning of your output.
+##Split
+Splitting one selected text layer to several by line break. Width of the text layers stay the same as the original.
+
+After splitting all created layers are selected so you can wrap them into autolayout, group or frame, or just drag around as you like.
+
+## Join
+
+Joining texts from the selected text layers into top-leftmost one, adding white spaces between merged texts. Width of the target layer stays preserved.
+
+## Details
+
+- Width of text layers preserved both with splitting and joining
+- Not throwing an error when joining or splitting texts with different parameters, all mixed styling just drops to first character's style.
+- If there a textstyle applied on the first character it is preserved on all the splitted layers
+- If there is a textstyle applyed to top-leftmost text layer when joining it will be applyed to the whole text.
+
+## Usage
+
+Instal it via Figma Community plugin page [here](https://www.figma.com/community/plugin/739131137116544548/TextCutter):
+
+It is handy to assign both commands to hotkeys and use it along with OCR software that helps extract texts from images, such as TextSniper.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # TextCutter
 
-TextCutter is a lightweight plugin for Figma to split or join text layers. There is no UI and it's focused on speed of interaction.
+TextCutter is a lightweight plugin for Figma to split or join text layers. There is no UI, and it's focused on speed of interaction.
 
-Plugin have two commands:
+There is two commands in the plugin:
 
-## Split
+## Split text
 
-Splitting one selected text layer to several by line break. Width of the text layers stay the same as the original.
+Splitting single selected text layer to several ones by the line break. The width of the text layers kept the same as the original.
 
-After splitting all created layers are selected so you can wrap them into autolayout, group or frame, or just drag around as you like.
+After splitting all created layers are selected, so you can wrap them into autolayout, group or frame, or just drag around as you like.
 
-## Join
+## Join text
 
-Joining texts from the selected text layers into top-leftmost one, adding white spaces between merged texts. Width of the target layer stays preserved.
+Merging all texts from the selected text layers into the top-leftmost one, adding white spaces between merged texts. Width of the target layer stays preserved.
 
 ## Details
 
 - Width of text layers preserved both with splitting and joining
-- Not throwing an error when joining or splitting texts with different parameters, all mixed styling just drops to first character's style.
-- If there a textstyle applied on the first character it is preserved on all the splitted layers
-- If there is a textstyle applyed to top-leftmost text layer when joining it will be applyed to the whole text.
+- Not throwing an error when joining or splitting texts with different parameters, all mixed styling just drops to the first character's style.
+- If there is a text style applied on the first character when splitting it is preserved on all the split layers
+- If there is a text style applied to the top-leftmost text layer when joining it will be applied to the whole text.
 
 ## Usage
 
-Instal it via Figma Community plugin page [here](https://www.figma.com/community/plugin/739131137116544548/TextCutter)
+Install it via Figma Community plugin page [here](https://www.figma.com/community/plugin/739131137116544548/TextCutter)
 
 It is handy to assign both commands to hotkeys and use it along with OCR software that helps extract texts from images, such as [TextSniper](https://textsniper.app/).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ TextCutter is a lightweight plugin for Figma to split or join text layers. There
 
 Plugin have two commands:
 
-##Split
+## Split
+
 Splitting one selected text layer to several by line break. Width of the text layers stay the same as the original.
 
 After splitting all created layers are selected so you can wrap them into autolayout, group or frame, or just drag around as you like.
@@ -22,6 +23,6 @@ Joining texts from the selected text layers into top-leftmost one, adding white 
 
 ## Usage
 
-Instal it via Figma Community plugin page [here](https://www.figma.com/community/plugin/739131137116544548/TextCutter):
+Instal it via Figma Community plugin page [here](https://www.figma.com/community/plugin/739131137116544548/TextCutter)
 
-It is handy to assign both commands to hotkeys and use it along with OCR software that helps extract texts from images, such as TextSniper.
+It is handy to assign both commands to hotkeys and use it along with OCR software that helps extract texts from images, such as [TextSniper](https://textsniper.app/).

--- a/textcutter-code/code.js
+++ b/textcutter-code/code.js
@@ -1,103 +1,164 @@
 // Figma plugin - Split multiline text
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
-    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
         function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
-        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
 // @author Johan Ronsse
-// @version 2.0
+// @version 3.0
 // @description
-//    Takes a layer with multiple lines of text and splits it
-//    into separate text layers. Empty lines get discarded automatically.
+//    Split and join text layers with lightweight noUI plugin
 /*
   Example use case: when you put text through OCR, you end up with a long string,
   which you will probably want in separate layers in Figma to start building a UI.
   This plugin avoids the manual splitting of layers.
 */
-/*
-  @todo position the text to right the original text, except when there is no space, then position it left
-  @todo Always consider that a text properties could have mixed values
-  @todo post a message when text has been splitted
-*/
+// Helper functions
+// Recursively checking if selected node is inside the instance — if it is we can't split layers, as we can't add new ones in instance 
+var nodeInInstance = (item) => {
+    if (item.parent.type == "PAGE") {
+        return false;
+    }
+    else {
+        if (item.parent.type == "INSTANCE") {
+            return true;
+        }
+        else {
+            nodeInInstance(item.parent);
+        }
+    }
+};
 function main() {
     return __awaiter(this, void 0, void 0, function* () {
-        // Roboto Regular is the font that objects will be created with by default in
-        // Figma. We need to wait for fonts to load before creating text using them.
-        yield figma.loadFontAsync({ family: "Roboto", style: "Regular" });
-        // First, some checks and balances.
-        // Make sure the selection is a single piece of text before proceeding.
-        if (figma.currentPage.selection.length !== 1) {
-            return "Select a single node.";
+        if (figma.command === 'split') {
+            // SPLIT COMMAND
+            // First, some checks and balances common for both commands
+            // Make sure the selection is a single piece of text before proceeding.
+            if (figma.currentPage.selection.length !== 1) {
+                return "Select a single text node to split.";
+            }
+            // Make sure we are dealing with a single text node
+            const node = figma.currentPage.selection[0];
+            if (node.type !== 'TEXT') {
+                return "Select a single text node to split.";
+            }
+            // Font check
+            if (node.hasMissingFont) {
+                return ('Whoops, you need to have the font for this layer installed.');
+            }
+            if (nodeInInstance(node)) {
+                return "Can’t split texts inside of the instance! Try splitting text in main component";
+            }
+            // We get the characters from our current selected layer, and parent to put individual lines in it later
+            var inputText = node.characters;
+            var nodeParent = node.parent;
+            var nodeFirstStyle = node.getRangeTextStyleId(0, 1);
+            // Detecting the font from the first character, loading it, and applying it to the whole node. This way we can drop styling without loading all used fonts
+            var nodeFirstFont = node.getRangeFontName(0, 1);
+            yield figma.loadFontAsync(nodeFirstFont);
+            // If there was style on the first character we applying it to whole text, if not, changing the font of whole text to one from the first character.
+            if (nodeFirstStyle) {
+                node.textStyleId = nodeFirstStyle;
+            }
+            else {
+                node.fontName = nodeFirstFont;
+            }
+            // This regex splits multiline string into multiple lines and puts it in an array
+            var result = inputText.split(/\r?\n/);
+            // Lines get sanitized in 2 ways:
+            // * All empty strings get removed (Boolean filter)
+            // * We trim away the whitespace at the end of the string
+            var filteredResults = result.filter(Boolean).map(s => s.trim());
+            // Checking if there is just one line in array, in that case doing nothing so original stays in place
+            if (filteredResults.length === 1) {
+                return "Nothing to split! There is only one row in the text layer";
+            }
+            // Now we need to make text layers that contain the text content of each of the array items
+            const nodes = [];
+            // Offset to position lines correctly
+            let vshift = 0;
+            // For each new line in array we duplicating original layer, populate it with line content, and place after the previous one
+            for (let i = 0; i < filteredResults.length; i++) {
+                const line = node.clone();
+                line.characters = filteredResults[i];
+                line.y = line.y + vshift;
+                line.textAutoResize = "HEIGHT";
+                vshift = vshift + line.height;
+                nodeParent.appendChild(line);
+                nodes.push(line);
+            }
+            // After all separate line nodes has been created, the original one is being deleted
+            node.remove();
+            // Selecting newly created list of layers. Layers are not grouped so can be immediatly put in frame, autolayout or just moved separately
+            figma.currentPage.selection = nodes;
+            // After job is done showing confirmation with number of layers created, and closing plugin
+            return `Splitted into ${nodes.length} layers`;
         }
-        // Make sure we are dealing with a single text node
-        const node = figma.currentPage.selection[0];
-        if (node.type !== 'TEXT') {
-            return "Select a single text node.";
+        if (figma.command === 'join') {
+            // JOIN COMMAND
+            //Filtering text layers from selection
+            var list = figma.currentPage.selection;
+            var textlist = list.filter(node => node.type == "TEXT");
+            // Checking if there is enough layers to join
+            if (textlist.length === 0) {
+                return "No text layers selected to join";
+            }
+            if (textlist.length < 2) {
+                return "Select at least 2 text layers to join";
+            }
+            // Font check
+            if (textlist.find(node => node.hasMissingFont)) {
+                return 'Whoops, you need to have the font for all selected layers installed first.';
+            }
+            // Finding the top-leftmost one from selected text layers. It will be our "main" node, we will merge joined text content into it later.
+            textlist.sort((a, b) => {
+                if ((a.y === b.absoluteTransform[1][2] &&
+                    a.absoluteTransform[0][2] < b.absoluteTransform[0][2]) ||
+                    a.absoluteTransform[1][2] < b.absoluteTransform[1][2]) {
+                    return -1;
+                }
+                if ((a.absoluteTransform[1][2] === b.absoluteTransform[1][2] &&
+                    a.absoluteTransform[0][2] > b.absoluteTransform[0][2]) ||
+                    a.absoluteTransform[1][2] > b.absoluteTransform[1][2]) {
+                    return 1;
+                }
+                return 0;
+            });
+            var mainNode = textlist[0];
+            // checking if there is text layers placed in instance among the text nodes.
+            if (textlist.filter(node => nodeInInstance(node)).length > 0) {
+                return "Can’t join texts from the layers inside of the instance! Try joining texts in main component";
+            }
+            // Collecting joined text from all text nodes into variable and removing all other text nodes apart from main one
+            var joinedText = '';
+            for (let i = 0; i < textlist.length; i++) {
+                if (textlist[i].type == "TEXT") {
+                    joinedText = joinedText == '' ? textlist[i].characters : joinedText + " " + textlist[i].characters;
+                }
+                if (i > 0) {
+                    textlist[i].remove();
+                }
+            }
+            // Dropping mixed styling and applying joined text to the main node
+            var nodeFirstStyle = mainNode.getRangeTextStyleId(0, 1);
+            // Detecting first character's font, loading it, and applying it to the whole node. This way we can drop styling without loading all used fonts
+            var nodeFirstFont = mainNode.getRangeFontName(0, 1);
+            yield figma.loadFontAsync(nodeFirstFont);
+            // If there was style on the first character we applying it to the whole text, if not, changing the font of the whole text to one from the first character.
+            if (nodeFirstStyle) {
+                mainNode.textStyleId = nodeFirstStyle;
+            }
+            else {
+                mainNode.fontName = nodeFirstFont;
+            }
+            mainNode.textAutoResize = "HEIGHT";
+            mainNode.characters = joinedText;
+            // After the job is done showing confirmation with number of layers joined, then closing plugin
+            return `Joined ${textlist.length} layers`;
         }
-        // Font check
-        if (node.hasMissingFont) {
-            return ('Whoops, you need to have the font for this layer installed.');
-        }
-        var nodeOriginalX = node.x;
-        var nodeOriginalY = node.y;
-        var nodeOriginalWidth = node.width;
-        // We get the characters from our current selected layer
-        var inputText = node.characters;
-        // We also get the styles from our selected layer
-        if (node.fontSize == figma.mixed) {
-            return ('Whoops, we do not support mixed font size values. Make sure all of your text is the same size.');
-        }
-        else {
-            var nodeFontSize = Number(node.fontSize);
-        }
-        if (node.fontName == figma.mixed) {
-            return ('Whoops, we do not support mixed font family values. Make sure all of your text is the same font family.');
-        }
-        else {
-            var nodeFontName = node.fontName;
-            console.log(nodeFontName);
-        }
-        let nodeFills = node.fills;
-        let nodeLineHeight = node.lineHeight;
-        let nodeLetterSpacing = node.letterSpacing;
-        let nodeTextCase = node.textCase;
-        let nodeTextDecoration = node.textDecoration;
-        yield figma.loadFontAsync(nodeFontName);
-        // This regex splits multiline string into multiple lines and puts it in an array
-        var result = inputText.split(/\r?\n/);
-        // Lines get sanitized in 2 ways:
-        // * All empty strings get removed (Boolean filter)
-        // * We trim away the whitespace at the end of the string
-        var filteredResults = result.filter(Boolean).map(s => s.trim());
-        // Now we need to make text layers that contain the text content of each of the array items
-        const nodes = [];
-        for (let i = 0; i < filteredResults.length; i++) {
-            const text = figma.createText();
-            // Need to replace this by the found text later
-            text.characters = filteredResults[i];
-            text.fontName = nodeFontName;
-            text.fontSize = nodeFontSize;
-            text.fills = nodeFills;
-            text.letterSpacing = nodeLetterSpacing;
-            text.lineHeight = nodeLineHeight;
-            text.textCase = nodeTextCase;
-            text.textDecoration = nodeTextDecoration;
-            // Space apart between the lines with some extra space to signify things have been split.
-            text.y = i * nodeFontSize;
-            figma.currentPage.appendChild(text);
-            nodes.push(text);
-        }
-        // Add everything to a group
-        let groupedNodes = figma.group(nodes, node.parent);
-        // Position the group to the right of the original group
-        groupedNodes.x = nodeOriginalX + nodeOriginalWidth * 1.5;
-        groupedNodes.y = nodeOriginalY;
-        figma.currentPage.selection = nodes;
-        figma.viewport.scrollAndZoomIntoView(nodes);
     });
 }
 main().then((message) => {

--- a/textcutter-code/code.ts
+++ b/textcutter-code/code.ts
@@ -1,10 +1,9 @@
 // Figma plugin - Split multiline text
 
 // @author Johan Ronsse
-// @version 2.0
+// @version 3.0
 // @description
-//    Takes a layer with multiple lines of text and splits it
-//    into separate text layers. Empty lines get discarded automatically.
+//    Split and join text layers with lightweight noUI plugin
 
 /*
   Example use case: when you put text through OCR, you end up with a long string,
@@ -12,111 +11,214 @@
   This plugin avoids the manual splitting of layers.
 */
 
-/*
-  @todo position the text to right the original text, except when there is no space, then position it left
-  @todo Always consider that a text properties could have mixed values
-  @todo post a message when text has been splitted
-*/
+
+  // Helper functions
+
+    // Recursively checking if selected node is inside the instance — if it is we can't split layers, as we can't add new ones in instance 
+    var nodeInInstance = (item) => {
+      if (item.parent.type == "PAGE"){
+        return false
+        
+      } 
+      else{
+        if (item.parent.type == "INSTANCE"){      
+        return true}
+        else{
+          nodeInInstance(item.parent)
+        }
+      }
+    }
+
+
+
+
 
 async function main(): Promise<string | undefined> {
 
-  // Roboto Regular is the font that objects will be created with by default in
-  // Figma. We need to wait for fonts to load before creating text using them.
-  await figma.loadFontAsync({ family: "Roboto", style: "Regular" })
 
-  // First, some checks and balances.
 
-  // Make sure the selection is a single piece of text before proceeding.
-  if (figma.currentPage.selection.length !== 1) {
-    return "Select a single node."
+if (figma.command === 'split'){
+
+// SPLIT COMMAND
+
+    // First, some checks and balances common for both commands
+
+    // Make sure the selection is a single piece of text before proceeding.
+    if (figma.currentPage.selection.length !== 1) {
+      return "Select a single text node to split."
+    }
+
+    // Make sure we are dealing with a single text node
+    const node = figma.currentPage.selection[0];
+
+    if (node.type !== 'TEXT') {
+      return "Select a single text node to split."
+    }
+
+    // Font check
+    if (node.hasMissingFont) {
+      return('Whoops, you need to have the font for this layer installed.');
+    }
+
+    if (nodeInInstance(node)){
+      return "Can’t split texts inside of the instance! Try splitting text in main component"
+    } 
+
+    // We get the characters from our current selected layer, and parent to put individual lines in it later
+    var inputText = node.characters;
+    var nodeParent = node.parent
+    var nodeFirstStyle = node.getRangeTextStyleId(0,1)
+    
+    // Detecting the font from the first character, loading it, and applying it to the whole node. This way we can drop styling without loading all used fonts
+
+    var nodeFirstFont = node.getRangeFontName(0,1)
+    await figma.loadFontAsync(nodeFirstFont as FontName)
+
+
+    // If there was style on the first character we applying it to whole text, if not, changing the font of whole text to one from the first character.
+    if (nodeFirstStyle){
+      node.textStyleId = nodeFirstStyle
+    }
+    else{
+      node.fontName = nodeFirstFont;
+    }
+
+    // This regex splits multiline string into multiple lines and puts it in an array
+    var result = inputText.split(/\r?\n/);
+
+    // Lines get sanitized in 2 ways:
+    // * All empty strings get removed (Boolean filter)
+    // * We trim away the whitespace at the end of the string
+
+    var filteredResults = result.filter(Boolean).map(s => s.trim());
+
+    // Checking if there is just one line in array, in that case doing nothing so original stays in place
+    if (filteredResults.length === 1){
+      return "Nothing to split! There is only one row in the text layer"
+    }
+
+    // Now we need to make text layers that contain the text content of each of the array items
+    const nodes: SceneNode[] = [];
+
+    // Offset to position lines correctly
+    let vshift = 0
+
+    // For each new line in array we duplicating original layer, populate it with line content, and place after the previous one
+    for (let i = 0; i < filteredResults.length; i++) {
+
+      const line = node.clone()
+      line.characters = filteredResults[i];
+      line.y = line.y + vshift
+      line.textAutoResize = "HEIGHT"
+      vshift = vshift + line.height
+      nodeParent.appendChild(line);
+      nodes.push(line);
+    }
+
+  // After all separate line nodes has been created, the original one is being deleted
+  node.remove()
+
+  // Selecting newly created list of layers. Layers are not grouped so can be immediatly put in frame, autolayout or just moved separately
+  figma.currentPage.selection = nodes;
+
+  // After job is done showing confirmation with number of layers created, and closing plugin
+  return `Splitted into ${nodes.length} layers`
   }
 
-  // Make sure we are dealing with a single text node
-  const node = figma.currentPage.selection[0];
 
-  if (node.type !== 'TEXT') {
-    return "Select a single text node."
+
+
+if (figma.command === 'join'){
+  
+  // JOIN COMMAND
+
+
+  //Filtering text layers from selection
+  var list = figma.currentPage.selection
+  var textlist = list.filter(node => node.type == "TEXT") as TextNode[]
+
+
+
+
+  // Checking if there is enough layers to join
+  if(textlist.length === 0) {
+    return "No text layers selected to join"
+  }
+
+  if(textlist.length < 2) {
+    return "Select at least 2 text layers to join"
   }
 
   // Font check
-  if (node.hasMissingFont) {
-    return('Whoops, you need to have the font for this layer installed.');
+  if(textlist.find(node => node.hasMissingFont)){
+    return 'Whoops, you need to have the font for all selected layers installed first.'
+  }
+  
+  // Finding the top-leftmost one from selected text layers. It will be our "main" node, we will merge joined text content into it later.
+
+  textlist.sort((a, b) => {
+    if (
+      (a.y === b.absoluteTransform[1][2] &&
+        a.absoluteTransform[0][2] < b.absoluteTransform[0][2]) ||
+      a.absoluteTransform[1][2] < b.absoluteTransform[1][2]
+    ) {
+      return -1;
+    }
+    if (
+      (a.absoluteTransform[1][2] === b.absoluteTransform[1][2] &&
+        a.absoluteTransform[0][2] > b.absoluteTransform[0][2]) ||
+      a.absoluteTransform[1][2] > b.absoluteTransform[1][2]
+    ) {
+      return 1;
+    }
+    return 0;
+  });
+
+  var mainNode = textlist[0]
+
+  // checking if there is text layers placed in instance among the text nodes.
+ 
+  
+  if(textlist.filter(node => nodeInInstance(node)).length > 0){
+    return "Can’t join texts from the layers inside of the instance! Try joining texts in main component"
   }
 
-  var nodeOriginalX = node.x;
-  var nodeOriginalY = node.y;
-  var nodeOriginalWidth = node.width;
 
-  // We get the characters from our current selected layer
-  var inputText = node.characters;
+  // Collecting joined text from all text nodes into variable and removing all other text nodes apart from main one
 
-  // We also get the styles from our selected layer
-  if (node.fontSize == figma.mixed) {
-    return('Whoops, we do not support mixed font size values. Make sure all of your text is the same size.');
-  } else {
-    var nodeFontSize = Number(node.fontSize);
-  }
-
-  if (node.fontName == figma.mixed) {
-    return('Whoops, we do not support mixed font family values. Make sure all of your text is the same font family.');
-  } else {
-    var nodeFontName = node.fontName;
-    console.log(nodeFontName);
-  }
-
-  let nodeFills = node.fills;
-  let nodeLineHeight = node.lineHeight;
-  let nodeLetterSpacing = node.letterSpacing;
-  let nodeTextCase = node.textCase;
-  let nodeTextDecoration = node.textDecoration;
-
-  await figma.loadFontAsync(nodeFontName as FontName);
-
-  // This regex splits multiline string into multiple lines and puts it in an array
-  var result = inputText.split(/\r?\n/);
-
-  // Lines get sanitized in 2 ways:
-  // * All empty strings get removed (Boolean filter)
-  // * We trim away the whitespace at the end of the string
-
-  var filteredResults = result.filter(Boolean).map(s => s.trim());
-
-  // Now we need to make text layers that contain the text content of each of the array items
-  const nodes: SceneNode[] = [];
-
-  for (let i = 0; i < filteredResults.length; i++) {
-
-    const text = figma.createText();
-    // Need to replace this by the found text later
-    text.characters = filteredResults[i];
-
-    text.fontName = nodeFontName;
-    text.fontSize = nodeFontSize;
-    text.fills = nodeFills;
-    text.letterSpacing = nodeLetterSpacing;
-    text.lineHeight = nodeLineHeight;
-    text.textCase = nodeTextCase;
-    text.textDecoration = nodeTextDecoration;
-
-    // Space apart between the lines with some extra space to signify things have been split.
-    text.y = i * nodeFontSize;
-    figma.currentPage.appendChild(text);
-    nodes.push(text);
-  }
-
-  // Add everything to a group
-  let groupedNodes = figma.group(nodes, node.parent);
-
-  // Position the group to the right of the original group
-  groupedNodes.x = nodeOriginalX + nodeOriginalWidth * 1.5;
-  groupedNodes.y = nodeOriginalY;
-
-  figma.currentPage.selection = nodes;
-  figma.viewport.scrollAndZoomIntoView(nodes);
-
+  var joinedText =''
+  for (let i = 0; i < textlist.length; i++) {
+    if (textlist[i].type == "TEXT"){
+      joinedText = joinedText==''? textlist[i].characters : joinedText + " " + textlist[i].characters
+    }
+    if (i > 0) {textlist[i].remove()}
 }
+
+// Dropping mixed styling and applying joined text to the main node
+
+var nodeFirstStyle = mainNode.getRangeTextStyleId(0,1)
+    
+// Detecting first character's font, loading it, and applying it to the whole node. This way we can drop styling without loading all used fonts
+
+var nodeFirstFont = mainNode.getRangeFontName(0,1)
+await figma.loadFontAsync(nodeFirstFont as FontName)
+
+// If there was style on the first character we applying it to the whole text, if not, changing the font of the whole text to one from the first character.
+if (nodeFirstStyle){
+  mainNode.textStyleId = nodeFirstStyle
+}
+else{
+  mainNode.fontName = nodeFirstFont;
+}
+mainNode.textAutoResize = "HEIGHT"
+mainNode.characters = joinedText
+
+// After the job is done showing confirmation with number of layers joined, then closing plugin
+return `Joined ${textlist.length} layers`
+}
+}
+
 
 main().then((message: string | undefined) => {
   figma.closePlugin(message)
 })
-

--- a/textcutter-code/manifest.json
+++ b/textcutter-code/manifest.json
@@ -1,6 +1,10 @@
 {
-  "name": "Split text",
+  "name": "TextCutter",
   "id": "739131137116544548",
   "api": "1.0.0",
-  "main": "code.js"
+  "main": "code.js",
+  "menu": [
+    {"name": "Split text", "command": "split"},
+    {"name": "Join text", "command": "join"}
+  ]
 }


### PR DESCRIPTION
Here is what changed:
 
- There is now two commands in plugin, “Split texts” and “Join texts” 
  - “Split” creating several layers with content split by line break in place of the original layer. Width of original layer preserved on created ones
  - “Join” merging the content of several selected text layers into top-leftmost one, adding white spaces between text layers content. Width and styles of the layer preserved.
- Fixed working with mixed styling, now plugin just silently drops any mixed properties to properties of the first character
- Works correctly in edge cases, not allowing to split or join texts inside the instances
- Some other tiny improvements under the hood
- Also updated Readme to reflect the changes